### PR TITLE
Fix 606a1 summary table tags loop.

### DIFF
--- a/Rule606ReportGenerator.js
+++ b/Rule606ReportGenerator.js
@@ -810,7 +810,7 @@ function getVenuesByMonth(month, year, securityType) { /* a1 */
 
 function getPublicRoutingBody(section, monthVal, year) { // a1
     var empty = true;
-    for (var i=0;i<a1SummaryTableTags[i];i++) {
+    for (var i=0;i<a1SummaryTableTags.length;i++) {
     	if (NS != getElementValueByMonth(a1SummaryTableTags[i],section, monthVal, year)) {
     		empty = false;
     		break;


### PR DESCRIPTION
With this change, the 606a1 summary table is populated. Without it, the for-loop ends immediately, skipping over the summary values and causing the summary table to appear empty.